### PR TITLE
COMP: Fixes array bounds warnings that arise when using O2 optimization ...

### DIFF
--- a/src/ell/eigen.c
+++ b/src/ell/eigen.c
@@ -695,6 +695,9 @@ ell_6ms_eigensolve_d(double eval[6], double _evec[36],
 
     P = maxI[0];
     Q = maxI[1];
+    if(P >=6 || Q >= 6){
+      break;
+    }
     th = (mat[cur][Q][Q] - mat[cur][P][P])/(2*mat[cur][P][Q]);
     tt = (th > 0 ? +1 : -1)/(AIR_ABS(th) + sqrt(th*th + 1));
     cc = 1/sqrt(tt*tt + 1);

--- a/src/nrrd/superset.c
+++ b/src/nrrd/superset.c
@@ -90,10 +90,19 @@ nrrdSplice(Nrrd *nout, const Nrrd *nin, const Nrrd *nslice,
     }
   }
   for (ai=0; ai<nslice->dim; ai++) {
-    if (!( nin->axis[ai + (ai >= axis)].size == nslice->axis[ai].size )) {
+    if(ai >= axis){
+      if (!( nin->axis[ai + 1].size == nslice->axis[ai].size )) {
+        biffAddf(NRRD, "%s: input ax %d size (%s) != slices ax %d size (%s)",
+                 me, ai + 1,
+                 airSprintSize_t(stmp[0], nin->axis[ai + 1].size), ai,
+                 airSprintSize_t(stmp[1], nslice->axis[ai].size));
+        return 1;
+      }
+    }
+    else if (!( nin->axis[ai].size == nslice->axis[ai].size )) {
       biffAddf(NRRD, "%s: input ax %d size (%s) != slices ax %d size (%s)",
-               me, ai + (ai >= axis),
-               airSprintSize_t(stmp[0], nin->axis[ai + (ai >= axis)].size), ai,
+               me, ai,
+               airSprintSize_t(stmp[0], nin->axis[ai].size), ai,
                airSprintSize_t(stmp[1], nslice->axis[ai].size));
       return 1;
     }

--- a/src/unrrdu/aabplot.c
+++ b/src/unrrdu/aabplot.c
@@ -111,7 +111,7 @@ unrrdu_aabplotMain(int argc, const char **argv, const char *me,
   {
 #define PTNUM 5
     double *in, *buff, ptile[PTNUM]={5,25,50,75,95};
-    unsigned int xi, yi, pi, ti, ltt, sx, sy, pti[PTNUM];
+    unsigned int xi, yi, pi, ti, sx, sy, pti[PTNUM];
     char *line, rbuff[128];
     Nrrd *nbuff;
 
@@ -158,7 +158,6 @@ unrrdu_aabplotMain(int argc, const char **argv, const char *me,
                 buff[airIndexClamp(0, ptile[ti], 100, sx)], pti[ti]);
         */
       }
-      ltt = (unsigned int)(-1);
       for (pi=0; pi<plen; pi++) {
         line[pi] = pi % 2 ? ' ' : '.';
       }
@@ -185,6 +184,7 @@ unrrdu_aabplotMain(int argc, const char **argv, const char *me,
       printf("\n");
 #if 0
       /* printf("["); */
+      unsigned int ltt = (unsigned int)(-1);
       for (pi=0; pi<plen; pi++) {
         for (tt=0; tt<PTNUM && pti[tt] < pi; tt++) {
           /*


### PR DESCRIPTION
...on GNUC compilers

Here is the fix for the warnings that were happening with teem in BRAINSTools.

When using O2 optimization, several false array bounds warnings occur. These were fixed by slightly changing the code that was triggering the warnings.

This update also fixes an unused variable warning.

Some of the code looks a bit awkward, but it is as neat as I could get it while making the compiler happy.

@hjmjohnson   This should take care of the teem warnings in BRAINSTools!