### PR TITLE
COMP: Fixes array-bounds warnings that occur when using O2 optimization ...

### DIFF
--- a/src/ell/eigen.c
+++ b/src/ell/eigen.c
@@ -686,15 +686,18 @@ ell_6ms_eigensolve_d(double eval[6], double _evec[36],
   iter = 0;
   while (sumoff/sumon > eps) {
     double th, tt, cc, ss;
-    unsigned int P, Q;
+    const unsigned int P = maxI[0];
+    const unsigned int Q = maxI[1];
+    //make sure that P and Q are within the bounds for mat[2][6][6]
+    if(P >=6 || Q >= 6){  
+      break;
+    }
     /*
     fprintf(stderr, "!%s(%u): sumoff/sumon = %g/%g = %g > %g\n", me, iter,
             sumoff, sumon, sumoff/sumon, eps);
     */
     cur = 1 - cur;
 
-    P = maxI[0];
-    Q = maxI[1];
     th = (mat[cur][Q][Q] - mat[cur][P][P])/(2*mat[cur][P][Q]);
     tt = (th > 0 ? +1 : -1)/(AIR_ABS(th) + sqrt(th*th + 1));
     cc = 1/sqrt(tt*tt + 1);

--- a/src/nrrd/superset.c
+++ b/src/nrrd/superset.c
@@ -90,10 +90,16 @@ nrrdSplice(Nrrd *nout, const Nrrd *nin, const Nrrd *nslice,
     }
   }
   for (ai=0; ai<nslice->dim; ai++) {
-    if (!( nin->axis[ai + (ai >= axis)].size == nslice->axis[ai].size )) {
-      biffAddf(NRRD, "%s: input ax %d size (%s) != slices ax %d size (%s)",
-               me, ai + (ai >= axis),
-               airSprintSize_t(stmp[0], nin->axis[ai + (ai >= axis)].size), ai,
+    const unsigned int indexOffset = (ai >= axis);
+    unsigned int foundExitCondition = 0;
+    if(indexOffset){
+      if( nin->axis[ai + 1].size != nslice ->axis[ai].size ) foundExitCondition = 1;
+    }
+    else if( nin->axis[ai].size != nslice ->axis[ai].size ) foundExitCondition = 1;
+    if ( foundExitCondition ) {
+      biffAddf(NRRD, "%s: input ax %u size (%s) != slices ax %u size (%s)",
+               me, ai + indexOffset,
+               airSprintSize_t(stmp[0], nin->axis[ai + indexOffset].size), ai,
                airSprintSize_t(stmp[1], nslice->axis[ai].size));
       return 1;
     }


### PR DESCRIPTION
Here is the fix for the warnings that were happening with teem in BRAINSTools.
Attempt #2!

When using O2 optimization, several false array bounds warnings occur. These were fixed by slightly changing the code that was triggering the warnings.

Some of the code looks a bit awkward, but it is as neat as I could get it while making the compiler happy.

@hjmjohnson Does this look better?