### PR TITLE
COMP: Fixes a set-but-not-used warning

### DIFF
--- a/src/unrrdu/aabplot.c
+++ b/src/unrrdu/aabplot.c
@@ -111,7 +111,7 @@ unrrdu_aabplotMain(int argc, const char **argv, const char *me,
   {
 #define PTNUM 5
     double *in, *buff, ptile[PTNUM]={5,25,50,75,95};
-    unsigned int xi, yi, pi, ti, ltt, sx, sy, pti[PTNUM];
+    unsigned int xi, yi, pi, ti, sx, sy, pti[PTNUM];
     char *line, rbuff[128];
     Nrrd *nbuff;
 
@@ -158,7 +158,6 @@ unrrdu_aabplotMain(int argc, const char **argv, const char *me,
                 buff[airIndexClamp(0, ptile[ti], 100, sx)], pti[ti]);
         */
       }
-      ltt = (unsigned int)(-1);
       for (pi=0; pi<plen; pi++) {
         line[pi] = pi % 2 ? ' ' : '.';
       }
@@ -184,6 +183,7 @@ unrrdu_aabplotMain(int argc, const char **argv, const char *me,
       }
       printf("\n");
 #if 0
+      unsigned int ltt = (unsigned int)(-1);
       /* printf("["); */
       for (pi=0; pi<plen; pi++) {
         for (tt=0; tt<PTNUM && pti[tt] < pi; tt++) {


### PR DESCRIPTION
Here is the second half of the fix for the warnings that were happening in BRAINSTools.

A variable that was only used withing a debugging loop was set and initialized in the main body of the code and was throwing a warning, so I moved it to be with the rest of the debugging loop.

@hjmjohnson here is the second part of the teem fix for BRAINSTools!

